### PR TITLE
Add the regression tests

### DIFF
--- a/.github/workflows/ventus-build.yml
+++ b/.github/workflows/ventus-build.yml
@@ -5,11 +5,15 @@ env:
   ISA_SIMULATOR: ventus-gpgpu-isa-simulator
   BUILD_TYPE: Release
   VENTUS_DRIVER: ventus-driver
+  RODINIA: gpu-rodinia
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   schedule:
     - cron: '0 2 * * *' # Runs at 2am everyday
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -40,10 +44,16 @@ jobs:
         git clone https://github.com/THU-DSP-LAB/pocl.git  ${{github.workspace}}/../$POCL
         git clone https://github.com/OCL-dev/ocl-icd.git ${{github.workspace}}/../$OCL_ICD
         git clone https://github.com/THU-DSP-LAB/ventus-gpgpu-isa-simulator.git ${{github.workspace}}/../$ISA_SIMULATOR
-        git clone https://github.com/yangzexia/ventus-driver.git ${{github.workspace}}/../$VENTUS_DRIVER
+        git clone https://github.com/THU-DSP-LAB/ventus-driver.git ${{github.workspace}}/../$VENTUS_DRIVER
+        git clone https://github.com/Jules-Kong/gpu-rodinia.git ${{github.workspace}}/../$RODINIA
         export DRIVER_DIR=${{github.workspace}}/../$VENTUS_DRIVER
         export DRIVER_BUILD_DIR=${DRIVER_DIR}/build
         export VENTUS_INSTALL_PREFIX=${{github.workspace}}/install
+        wget -P ${{github.workspace}}/../$RODINIA -c https://www.dropbox.com/s/cc6cozpboht3mtu/rodinia-3.1-data.tar.gz
+        tar -zxvf ${{github.workspace}}/../$RODINIA/rodinia-3.1-data.tar.gz -C ${{github.workspace}}/../$RODINIA
+        mv ${{github.workspace}}/../$RODINIA/rodinia-data/* ${{github.workspace}}/../$RODINIA/data/
+        rm ${{github.workspace}}/../$RODINIA/rodinia-3.1-data.tar.gz
+        rm ${{github.workspace}}/../$RODINIA/rodinia-data -rf
 
     - name: Start building llvm-ventus
       shell: bash
@@ -74,6 +84,16 @@ jobs:
       shell: bash
       run: |
         bash build-ventus.sh --build ${POCL}
+
+    - name: Start testing gpu-rodinia
+      shell: bash
+      run: |
+         bash build-ventus.sh --build rodinia
+
+    - name: Start testing pocl
+      shell: bash
+      run: |
+         bash build-ventus.sh --build test-pocl
 
     - name: Start ISA simulation test
       run: |


### PR DESCRIPTION
In order to prevent new errors from being introduced when modifying the code, we add regression tests in the project build script and workflow. The regression test mainly includes some use cases that come with gpu-rodinia and pocl.
