### PR TITLE
[VENTUS][NFC] Modify build script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,16 +139,17 @@ Use [spike](https://github.com/THU-DSP-LAB/ventus-gpgpu-isa-simulator) from THU 
 #### 4.4: Driver using example
 
 Accordingly, after all the building process, you can change directory to `<llvm-ventus-parentFolder>/pocl/build/examples/vecadd` directory, then export variables as what [Bridge icd loader](#3-bridge-icd-loader) does, finally just execute the file `vecadd`
-### 5: TODOs
 
-* Emit `barrier` instruction for all stores to local/global memory except sGPR spill.
-* Stacks for sGPR spilling and per-thread usage is supported by using RISCV::X2 as warp level stack, RISCV::X4 as per-thread level stack. But the 2 stack size calculation are not yet splitted out, so a lot of stack slots are wasted.
-* ~~Pattern match VV and VX optimization. There is only type information in the DAG pattern matching, we can't specify whether to match a DAG to a vop.vv or vop.vx MIR in a tblgen pattern, so a fix pass should be ran after codegen pass~~.
-* Opencl kernel api - get_enqueued_local_size, need to support non-uniform workgroup
-* `mem_fence` builtin support
+### 5: Github actions
 
-### 6: Github actions
+the workflow file is `.github/workflows/ventus-build.yml`, including below jobs
 
-We add a customized action for VENTUS including `Building ventus` and `Building ISA simulator`, later we will add `Test workflow` to make all the process automatable,
-the workflow file is `.github/workflows/ventus-build.yml`
-
+* Build llvm
+* Build ocl-icd
+* Build libclc
+* Build isa-simulator
+* Build sumulator-driver
+* Build pocl
+* Isa simulation test
+* GPU-rodinia testsuite
+* Pocl testing

--- a/build-ventus.sh
+++ b/build-ventus.sh
@@ -166,7 +166,6 @@ build_pocl() {
     -DSTATIC_LLVM=OFF \
     -DCMAKE_C_COMPILER=clang \
     -DCMAKE_CXX_COMPILER=clang++ \
-    -DCMAKE_CXX_FLAGS="-fuse-ld=lld" \
     -DCMAKE_INSTALL_PREFIX=${VENTUS_INSTALL_PREFIX}
   ninja -C ${POCL_BUILD_DIR}
   ninja -C ${POCL_BUILD_DIR} install

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.h
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.h
@@ -334,10 +334,11 @@ enum NodeType : unsigned {
 
 class RISCVTargetLowering : public TargetLowering {
   const RISCVSubtarget &Subtarget;
-
+  int *VastartStoreFrameIndex = new int;
 public:
   explicit RISCVTargetLowering(const TargetMachine &TM,
                                const RISCVSubtarget &STI);
+  ~RISCVTargetLowering() { delete VastartStoreFrameIndex; }
 
   const RISCVSubtarget &getSubtarget() const { return Subtarget; }
 
@@ -477,6 +478,12 @@ public:
 
   ISD::NodeType getExtendForAtomicCmpSwapArg() const override {
     return ISD::SIGN_EXTEND;
+  }
+
+  int getVastartStoreFrameIndex() const { return *VastartStoreFrameIndex; }
+
+  void setVastartStoreFrameIndex(int Index) const {
+    *VastartStoreFrameIndex = Index;
   }
 
   bool shouldExpandShift(SelectionDAG &DAG, SDNode *N) const override {

--- a/llvm/lib/Target/RISCV/VentusInstrInfo.td
+++ b/llvm/lib/Target/RISCV/VentusInstrInfo.td
@@ -40,10 +40,17 @@ class DivergentPrivateLoadFrag<SDPatternOperator Op> : PatFrag<
   (ops node:$src0),
   (Op $src0),
   [{
+    const LoadSDNode *L = cast<LoadSDNode>(N);
+    bool IsDivergent = false;
+    if( auto *Base = dyn_cast<LoadSDNode>(L->getBasePtr()))
+      if(auto *BaseBase = dyn_cast<FrameIndexSDNode>(Base->getOperand(1)))
+        if(BaseBase->getIndex() == CurDAG->getMachineFunction().
+getSubtarget<RISCVSubtarget>().getTargetLowering()->getVastartStoreFrameIndex())
+          IsDivergent = true;
     return N->isDivergent() &&
       (cast<LoadSDNode>(N)->getAddressSpace() == RISCVAS::PRIVATE_ADDRESS ||
       cast<LoadSDNode>(N)->getPointerInfo().StackID == RISCVStackID::VGPRSpill
-      );
+      || IsDivergent);
   }]>;
 
 class DivergentNonPrivateLoadFrag<SDPatternOperator Op> : PatFrag<

--- a/llvm/lib/Target/RISCV/VentusInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/VentusInstrInfoV.td
@@ -1230,6 +1230,19 @@ def VFTTA : RVInstIVI<0b000011, (outs VGPR:$vd_wb),
 // Ventus vALU divergent execution patterns
 //===----------------------------------------------------------------------===//
 
+// ATTENTION: please don't change the pattern order
+// Private memory per-thread load/store
+def : DivergentPriLdPat<load, VLW>;
+def : DivergentPriLdPat<zextloadi16, VLHU>;
+def : DivergentPriLdPat<sextloadi16, VLH>;
+def : DivergentPriLdPat<extloadi16, VLH>;
+def : DivergentPriLdPat<zextloadi8, VLBU>;
+def : DivergentPriLdPat<extloadi8, VLB>;
+def : DivergentPriLdPat<sextloadi8, VLB>;
+def : DivergentPriStPat<store, VSW>;
+def : DivergentPriStPat<truncstorei16, VSH>;
+def : DivergentPriStPat<truncstorei8, VSB>;
+
 // Non-private memory load/store
 // TODO: add store/load test file for testing pattern match
 def : DivergentNonPriLdImmPat<load, VLWI12>;
@@ -1252,18 +1265,6 @@ def : DivergentNonPriLdPat<load, VLUXEI32>;
 def : DivergentNonPriStPat<truncstorei8, VSUXEI8>;
 def : DivergentNonPriStPat<truncstorei16, VSUXEI16>;
 def : DivergentNonPriStPat<store, VSUXEI32>;
-
-// Private memory per-thread load/store
-def : DivergentPriLdPat<load, VLW>;
-def : DivergentPriLdPat<zextloadi16, VLHU>;
-def : DivergentPriLdPat<sextloadi16, VLH>;
-def : DivergentPriLdPat<extloadi16, VLH>;
-def : DivergentPriLdPat<zextloadi8, VLBU>;
-def : DivergentPriLdPat<extloadi8, VLB>;
-def : DivergentPriLdPat<sextloadi8, VLB>;
-def : DivergentPriStPat<store, VSW>;
-def : DivergentPriStPat<truncstorei16, VSH>;
-def : DivergentPriStPat<truncstorei8, VSB>;
 
 // FIXME: check this review: https://reviews.llvm.org/D131729#inline-1269307
 // def : PatIntSetCC<[VGPR, VGPR], SETLE, VMSLE_VV>;


### PR DESCRIPTION
In standard riscv vararg support, the varstart frame index will be stored in stack,
but because if the design of ventus, some code generation  will be like this
	vlw.v	v0, -44(v8)
	vadd.vi	v1, v0, 4
	vsw.v	v1, -44(v8)
	vlw12.v	v0, 0(v0)
the last vlw12 instruction is actually illeagl, it should be vlw# **DO NOT FILE A PULL REQUEST**
