### PR TITLE
[VENTUS][fix] Fix add_sat(char,char), add_sat(uchar,uchar) calculation error

### DIFF
--- a/libclc/generic/lib/integer/add_sat.cl
+++ b/libclc/generic/lib/integer/add_sat.cl
@@ -13,12 +13,20 @@ _CLC_DECL ulong  __clc_add_sat_u64(ulong, ulong);
 
 _CLC_OVERLOAD _CLC_DEF char add_sat(char x, char y) {
   short r = x + y;
-  return convert_char_sat(r);
+  if(r >= CHAR_MAX)
+    return CHAR_MAX;
+  else if(r <= CHAR_MIN)
+    return CHAR_MIN;
+  return (char)r;
 }
 
 _CLC_OVERLOAD _CLC_DEF uchar add_sat(uchar x, uchar y) {
   ushort r = x + y;
-  return convert_uchar_sat(r);
+  if(r >= UCHAR_MAX)
+    return UCHAR_MAX;
+  else if(r <= 0)
+    return 0;
+  return (uchar)r;
 }
 
 _CLC_OVERLOAD _CLC_DEF short add_sat(short x, short y) {


### PR DESCRIPTION
`add_sat` 是 OpenCL 中的一个内置函数，用于执行饱和加法运算。"饱和"指的是当结果
超出其数据类型能表示的最大或最小值时，结果会被设置为该数据类型的最大或最小值，
而不是发生溢出. 具体来说，`add_sat` 函数接受两个参数，执行加法运算，并返回结果。
如果结果超过了数据类型的最大值，它将返回该数据类型的最大值；如果结果小于数据类型
的最小值，它将返回该数据类型的最小值. 例如，对于 `char` 类型范围是(-128 到 127), 如果你试图计算 `127 + 10`，一个普通的加法运算会发生溢出，结果不确定。但如果你使用
`add_sat`，它将返回 `char` 类型的最大值 `127`. 这是使用 `add_sat` 的一个例子:
```c
char a = 127;
char b = 10;
char result = add_sat(a, b);  // result is 127
```
这个函数可以用于各种数据类型，包括标量和向量类型，如 `int`, `uint`, `short`, `ushort`, `char`, `uchar`, `intn`, `uintn`, `shortn`, `ushortn`, `charn`, `ucharn` 等。
