### PR TITLE
[VENTUS][RISCV] Fix move instructions after JOIN move forward bug

### DIFF
--- a/llvm/lib/Target/RISCV/VentusInsertJoinToVBranch.cpp
+++ b/llvm/lib/Target/RISCV/VentusInsertJoinToVBranch.cpp
@@ -236,8 +236,20 @@ bool VentusInsertJoinToVBranch::checkJoinMBB(MachineBasicBlock &MBB) const {
           if (&MI1 == &Def)
             Insert = MI1.getIterator();
         }
-        if (Insert != Pre->begin()) {
+        if (Insert != Pre->begin() || Pre->begin() == &Def) {
           // Last instruction define in Pre MBB
+          bool IsInsert = false;
+          for(auto Pair : MBBMaybeInsertedInstr) {
+            if (Pair.first == Pre) {
+              IsInsert = true;
+              break;
+            }
+          }
+
+          // Only last MI in Pre need to insert
+          if (IsInsert)
+            continue;
+
           NeedToBeInsertMBBNum++;
           MBBMaybeInsertedInstr.push_back({Pre, Insert});
         }


### PR DESCRIPTION
1. If the move instruction needs to be moved forward, it will only be inserted after the last corresponding move instruction in the predecessor basic block.
2. The first instruction of the predecessor is also counted as a possible insertion point.

# **DO NOT FILE A PULL REQUEST**

This repository does not accept pull requests. Please follow http://llvm.org/docs/Contributing.html#how-to-submit-a-patch for contribution to LLVM.

# **DO NOT FILE A PULL REQUEST**
