### PR TITLE
[VENTUS][fix] Add memory access flags in tablegen

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -102,6 +102,10 @@ enum {
 
   IsVOPIMM11Shift = IsVVALUInstrShift + 1,
   IsVOPIMM11Mask = 1 << IsVOPIMM11Shift,
+
+  MemScopeShift = IsVOPIMM11Shift + 1,
+  MemScopeMask = 0b11 << MemScopeShift
+
 };
 
 // Match with the definitions in RISCVInstrFormats.td
@@ -110,6 +114,12 @@ enum VConstraintType {
   VS2Constraint = 0b001,
   VS1Constraint = 0b010,
   VMConstraint = 0b100,
+};
+
+enum MemScope {
+  DefaultMemScope = 0b00,
+  LocalMemScope = 0b01,
+  PrivateMemScope = 0b10
 };
 
 enum VLMUL : uint8_t {
@@ -133,6 +143,12 @@ static inline unsigned getFormat(uint64_t TSFlags) {
 static inline VConstraintType getConstraint(uint64_t TSFlags) {
   return static_cast<VConstraintType>((TSFlags & ConstraintMask) >>
                                       ConstraintShift);
+}
+
+/// \returns the memory access scope for the instruction.
+static inline MemScope getMemScope(uint64_t TSFlags) {
+  return static_cast<MemScope>((TSFlags & MemScopeMask) >>
+                                      MemScopeShift);
 }
 
 /// \returns true if there is a dummy mask operand for the instruction.

--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -211,6 +211,12 @@ class RVInst<dag outs, dag ins, string opcodestr, string argstr,
 
   bit IsVOPIMM11 = 0;
   let TSFlags{20} = IsVOPIMM11;
+
+  // 0: global and constant
+  // 1: shared/local
+  // 2: private
+  bits<2> MemScope = 0;
+  let TSFlags{22-21} = MemScope;
 }
 
 // Pseudo instructions

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -96,51 +96,18 @@ unsigned RISCVInstrInfo::isLoadFromStackSlot(const MachineInstr &MI,
 }
 
 bool RISCVInstrInfo::isPrivateMemoryAccess(const MachineInstr &MI) const {
-  switch (MI.getOpcode()) {
-    default:
-      return false;
-    case RISCV::VLW:
-    case RISCV::VLB:
-    case RISCV::VLBU:
-    case RISCV::VLH:
-    case RISCV::VLHU:
-    case RISCV::VSW:
-    case RISCV::VSH:
-    case RISCV::VSB:
-      return true;
-  }
+ return RISCVII::getMemScope(MI.getDesc().TSFlags) ==
+         RISCVII::MemScope::PrivateMemScope;
 }
 
 bool RISCVInstrInfo::isUniformMemoryAccess(const MachineInstr &MI) const {
-  switch (MI.getOpcode()) {
-    default:
-      return false;
-    case RISCV::LW:
-    case RISCV::LB:
-    case RISCV::LBU:
-    case RISCV::LH:
-    case RISCV::LHU:
-    case RISCV::SW:
-    case RISCV::SH:
-    case RISCV::SB:
-      return true;
-  }
+  return RISCVII::getMemScope(MI.getDesc().TSFlags) ==
+         RISCVII::MemScope::DefaultMemScope;
 }
 
 bool RISCVInstrInfo::isLocalMemoryAccess(const MachineInstr &MI) const {
-  switch (MI.getOpcode()) {
-    default:
-      return false;
-    case RISCV::VLWI12:
-    case RISCV::VLBI12:
-    case RISCV::VLBUI12:
-    case RISCV::VLHI12:
-    case RISCV::VLHUI12:
-    case RISCV::VSWI12:
-    case RISCV::VSHI12:
-    case RISCV::VSBI12:
-      return true;
-  }
+ return RISCVII::getMemScope(MI.getDesc().TSFlags) ==
+         RISCVII::MemScope::LocalMemScope;
 }
 
 
@@ -214,6 +181,7 @@ unsigned RISCVInstrInfo::isStoreToStackSlot(const MachineInstr &MI,
   case RISCV::SD:
   case RISCV::VSW:
   case RISCV::VSH:
+  case RISCV::VSB:
     break;
   }
 

--- a/llvm/lib/Target/RISCV/VentusInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/VentusInstrInfoV.td
@@ -711,6 +711,7 @@ class VENTUS_VL<bits<3> funct3, string opcodestr>
               opcodestr # ".v", "$rd, ${imm12}(${rs1})"> {
   let Inst{31} = 0;
   let Inst{30-20} = imm12{10-0};
+  let MemScope = 0b10;
 }
 class VENTUS_VS<bits<3> funct3, string opcodestr>
     : RVInstS<funct3, OPC_CUSTOM_1, (outs),
@@ -719,17 +720,23 @@ class VENTUS_VS<bits<3> funct3, string opcodestr>
   let Inst{31} = 1;
   let Inst{30-25} = imm12{10-5};
   let Inst{11-7} = imm12{4-0};
+  let MemScope = 0b10;
 }
 
 // Local/Global memory load/store instructions
 class VENTUS_VLI12<bits<3> funct3, string opcodestr> :
               RVInstI<funct3, OPC_CUSTOM_3, (outs VGPR:$rd),
               (ins VGPRMem:$rs1, simm12:$imm12),
-              opcodestr # ".v" , "$rd, ${imm12}(${rs1})">, Sched<[]>;
+              opcodestr # ".v" , "$rd, ${imm12}(${rs1})">, Sched<[]> {
+  let MemScope = 0b01;
+}
+
 class VENTUS_VSI12<bits<3> funct3, string opcodestr> :
               RVInstS<funct3, OPC_CUSTOM_3, (outs),
               (ins VGPR:$rs2, VGPRMem:$rs1, simm12:$imm12),
-              opcodestr # ".v", "$rs2, ${imm12}(${rs1})">, Sched<[]>;
+              opcodestr # ".v", "$rs2, ${imm12}(${rs1})">, Sched<[]> {
+  let MemScope = 0b01;
+}
 
 //===----------------------------------------------------------------------===//
 // Instructions


### PR DESCRIPTION
In this way, it is better to judge what memory scope is accessed by load/store instructions