### PR TITLE
[VENTUS][fix] Fix memory flags set in tablegen #129

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVBaseInfo.h
@@ -117,9 +117,9 @@ enum VConstraintType {
 };
 
 enum MemScope {
-  DefaultMemScope = 0b00,
-  LocalMemScope = 0b01,
-  PrivateMemScope = 0b10
+  DefaultMemScope = 0b01,
+  LocalMemScope = 0b10,
+  PrivateMemScope = 0b11
 };
 
 enum VLMUL : uint8_t {

--- a/llvm/lib/Target/RISCV/VentusInstrInfo.td
+++ b/llvm/lib/Target/RISCV/VentusInstrInfo.td
@@ -714,7 +714,9 @@ class BranchCC_rri<bits<3> funct3, string opcodestr>
 let hasSideEffects = 0, mayLoad = 1, mayStore = 0 in {
 class Load_ri<bits<3> funct3, string opcodestr>
     : RVInstI<funct3, OPC_LOAD, (outs GPR:$rd), (ins GPRMem:$rs1, simm12:$imm12),
-              opcodestr, "$rd, ${imm12}(${rs1})">;
+              opcodestr, "$rd, ${imm12}(${rs1})"> {
+    let MemScope = 0b01;
+  }
 
 class HLoad_r<bits<7> funct7, bits<5> funct5, string opcodestr>
     : RVInstR<funct7, 0b100, OPC_SYSTEM, (outs GPR:$rd),
@@ -732,7 +734,9 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 1 in {
 class Store_rri<bits<3> funct3, string opcodestr>
     : RVInstS<funct3, OPC_STORE, (outs),
               (ins GPR:$rs2, GPRMem:$rs1, simm12:$imm12),
-              opcodestr, "$rs2, ${imm12}(${rs1})">;
+              opcodestr, "$rs2, ${imm12}(${rs1})"> {
+    let MemScope = 0b01;
+  }
 
 class HStore_rr<bits<7> funct7, string opcodestr>
     : RVInstR<funct7, 0b100, OPC_SYSTEM, (outs),

--- a/llvm/lib/Target/RISCV/VentusInstrInfoV.td
+++ b/llvm/lib/Target/RISCV/VentusInstrInfoV.td
@@ -711,7 +711,7 @@ class VENTUS_VL<bits<3> funct3, string opcodestr>
               opcodestr # ".v", "$rd, ${imm12}(${rs1})"> {
   let Inst{31} = 0;
   let Inst{30-20} = imm12{10-0};
-  let MemScope = 0b10;
+  let MemScope = 0b11;
 }
 class VENTUS_VS<bits<3> funct3, string opcodestr>
     : RVInstS<funct3, OPC_CUSTOM_1, (outs),
@@ -720,7 +720,7 @@ class VENTUS_VS<bits<3> funct3, string opcodestr>
   let Inst{31} = 1;
   let Inst{30-25} = imm12{10-5};
   let Inst{11-7} = imm12{4-0};
-  let MemScope = 0b10;
+  let MemScope = 0b11;
 }
 
 // Local/Global memory load/store instructions
@@ -728,14 +728,14 @@ class VENTUS_VLI12<bits<3> funct3, string opcodestr> :
               RVInstI<funct3, OPC_CUSTOM_3, (outs VGPR:$rd),
               (ins VGPRMem:$rs1, simm12:$imm12),
               opcodestr # ".v" , "$rd, ${imm12}(${rs1})">, Sched<[]> {
-  let MemScope = 0b01;
+  let MemScope = 0b10;
 }
 
 class VENTUS_VSI12<bits<3> funct3, string opcodestr> :
               RVInstS<funct3, OPC_CUSTOM_3, (outs),
               (ins VGPR:$rs2, VGPRMem:$rs1, simm12:$imm12),
               opcodestr # ".v", "$rs2, ${imm12}(${rs1})">, Sched<[]> {
-  let MemScope = 0b01;
+  let MemScope = 0b10;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
In previous logic ,default memory access flag is 0b00, this will cause all no-local/no-private related instructions return true when fall into `RISCVInstrInfo::isUniformMemoryAccess` logic

