### PR TITLE
[VENTUS][fix] Fix double add and mul operation

### DIFF
--- a/llvm/lib/CodeGen/TargetPassConfig.cpp
+++ b/llvm/lib/CodeGen/TargetPassConfig.cpp
@@ -916,7 +916,7 @@ void TargetPassConfig::addIRPasses() {
 
   // Prepare expensive constants for SelectionDAG.
   if (getOptLevel() != CodeGenOpt::None && !DisableConstantHoisting)
-    addPass(createConstantHoistingPass());
+    // addPass(createConstantHoistingPass());
 
   if (getOptLevel() != CodeGenOpt::None)
     addPass(createReplaceWithVeclibLegacyPass());


### PR DESCRIPTION
Passed test_geometrics in CTS.
Constant-Hoisting pass的作用是减少重复的常量加载，而立即数指令只能使用标量寄存器，这就导致在分支中寄存器状态会被修改，double浮点运算计算错误。
