### PR TITLE
fix: update shebang in build-ventus.sh to ensure compatibility

### DIFF
--- a/build-ventus.sh
+++ b/build-ventus.sh
@@ -1,4 +1,4 @@
-#!bash
+#!/usr/bin/env bash
 
 DIR=$(cd "$(dirname "${0}")" &> /dev/null && (pwd -W 2> /dev/null || pwd))
 VENTUS_BUILD_DIR=${DIR}/build


### PR DESCRIPTION
Replaced `#!bash` with `#!/usr/bin/env bash` in build-ventus.sh to ensure the script uses the correct Bash interpreter across different environments.
