### PR TITLE
fix:  add `--init vectorAdd` to README linking example #156

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Then, run the commands listed as follows under the same directory.
 Linking `crt0` and `libclc`
 All the libclc workitem functions' implementation is included in `riscv32clc.o`
 ```sh
-./install/bin/ld.lld -o vecadd.riscv -T utils/ldscripts/ventus/elf32lriscv.ld vecadd.o ./install/lib/crt0.o ./install/lib/riscv32clc.o -L./install/lib -lworkitem --gc-sections
+./install/bin/ld.lld -o vecadd.riscv -T utils/ldscripts/ventus/elf32lriscv.ld vecadd.o ./install/lib/crt0.o ./install/lib/riscv32clc.o -L./install/lib -lworkitem --gc-sections --init vectorAdd
 ```
 
 ##### 4.1.3 Compile assembly code to object file (`.s` to `.o`)


### PR DESCRIPTION
## Linker Initialization Function

Added `--init vectorAdd` to explicitly specify the initialization function for the executable. Without this flag, the `vectorAdd` symbol was not visible in the symbol table when using `llvm-readelf -s vecadd.riscv`.

Key reasons for adding the flag:
- Ensures the `vectorAdd` function is recognized in the executable's symbol table
- Controls the program's initialization sequence
- Guarantees the correct placement of the `vectorAdd` symbol during linking

Before adding `--init`:
- `llvm-readelf -s vecadd.riscv | grep vectorAdd` showed no symbol

After adding `--init vectorAdd`:
- The symbol appears with a valid address (0x800000b8)
- Confirms successful symbol inclusion in the executable