### PR TITLE
docs: add POCL_ENABLE_UNINIT note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Run `export LD_LIBRARY_PATH=${VENTUS_INSTALL_PREFIX}/lib` to tell OpenCL applica
 
 Run `export OCL_ICD_VENDORS=${VENTUS_INSTALL_PREFIX}/lib/libpocl.so` to tell ocl icd loader where the icd driver is.
 
+Run `export POCL_ENABLE_UNINIT=1` to enable automatic device uninitialization when the last OpenCL context is released. 
+
 Finally, run `export POCL_DEVICES="ventus"` to tell pocl driver which device is available(should we set ventus as default device?). You will see Ventus GPGPU device is found if your setup is correct:
 ```
 $ <pocl-install-dir>/bin/poclcc -l

--- a/build-ventus.sh
+++ b/build-ventus.sh
@@ -238,6 +238,7 @@ export_elements() {
   export SPIKE_SRC_DIR=${SPIKE_DIR}
   export SPIKE_TARGET_DIR=${VENTUS_INSTALL_PREFIX}
   export VENTUS_INSTALL_PREFIX=${VENTUS_INSTALL_PREFIX}
+  export POCL_ENABLE_UNINIT=1
   export POCL_DEVICES="ventus"
   export OCL_ICD_VENDORS=${VENTUS_INSTALL_PREFIX}/lib/libpocl.so
 }


### PR DESCRIPTION
What:
Add a line to README.md explaining how to enable automatic deinitialization of the device when the last OpenCL context is released via the environment variable POCL_ENABLE_UNINIT=1.
Why:
This variable is useful for running or debugging Ventus device tests, and the documentation does not state that it can cause user configuration difficulties. Adding prompts to the README can help users quickly configure and avoid misunderstandings.
Tests:
Only document modifications, no code changes; It is recommended to merge after CI passage.
