### PR TITLE
[VENTUS] try fix (float)(4-j)

### DIFF
--- a/llvm/lib/Target/RISCV/VentusInstrInfoF.td
+++ b/llvm/lib/Target/RISCV/VentusInstrInfoF.td
@@ -691,6 +691,8 @@ def : Pat<(i32 (UniformUnaryFrag<any_lround> GPRF32:$rs1)), (FCVT_W_S $rs1, 0b10
 // [u]int->float. Match GCC and default to using dynamic rounding mode.
 def : Pat<(UniformUnaryFrag<any_sint_to_fp> (i32 GPR:$rs1)), (FCVT_S_W $rs1, 0b111)>;
 def : Pat<(UniformUnaryFrag<any_uint_to_fp> (i32 GPR:$rs1)), (FCVT_S_WU $rs1, 0b111)>;
+def : Pat<(any_sint_to_fp (sub simm5:$imm, (i32 GPR:$rs1))),
+          (FCVT_S_W (ADDI (SUB X0, GPR:$rs1), simm5:$imm), 0b111)>;
 } // Predicates = [HasStdExtZfinx, IsRV32]
 
 let Predicates = [HasStdExtZfinx, IsRV64] in {


### PR DESCRIPTION
1. 在编译类似(float)(4-j)，j是输入参数，放在标量寄存器中；会吧(4-j)对应匹配成PseudoVRSUB_VI_IMM11，结果会放到向量寄存器中；然后强转符号(float)匹配陈源操作数标量寄存器的FCVT_S_W，这样中间就需要有向量寄存器复制到标量寄存器。
2. 向量寄存器复制到标量寄存器应该语义上不合理吧，会报错Illegal copy from VGPR to SGPR


llvm ir:

`
   %0 = load float, ptr addrspace(1) %arrayidx, align 4, !tbaa !10
  %sub = sub nsw i32 4, %j
  %conv = sitofp i32 %sub to float
`

opencl code
`
#ifndef _KERNEL_
#define _KERNEL_

__kernel void time_step(int j, int nelr, 
                                __global float* old_variables, 
                                __global float* variables, 
                                __global float* step_factors, 
                                __global float* fluxes){

        const int i = get_global_id(0);
        if( i >= nelr ) return;
        float factor = step_factors[i]/(float)(4-j);
        variables[i] = old_variables[i] + factor*fluxes[i];
}

#endi
`
