### PR TITLE
[VENTUS][FEAT] Enable promote small-vector alloca

### DIFF
--- a/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -44,6 +44,7 @@ add_llvm_target(RISCVCodeGen
   VentusFixMixedPHI.cpp
   VentusInsertJoinToVBranch.cpp
   VentusLegalizeLoad.cpp
+  VentusPromoteAlloca.cpp
   GISel/RISCVCallLowering.cpp
   GISel/RISCVInstructionSelector.cpp
   GISel/RISCVLegalizerInfo.cpp

--- a/llvm/lib/Target/RISCV/RISCV.h
+++ b/llvm/lib/Target/RISCV/RISCV.h
@@ -82,6 +82,10 @@ void initializeVentusInsertJoinToVBranchPass(PassRegistry &);
 FunctionPass *createVentusFixMixedPHIPass();
 void initializeVentusFixMixedPHIPass(PassRegistry &);
 
+FunctionPass *createVentusPromoteAllocaPass();
+void initializeVentusPromoteAllocaPass(PassRegistry &);
+extern char &VentusPromoteAllocaID;
+
 InstructionSelector *createRISCVInstructionSelector(const RISCVTargetMachine &,
                                                     RISCVSubtarget &,
                                                     RISCVRegisterBankInfo &);

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -68,6 +68,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeRISCVTarget() {
   initializeRISCVPreRAExpandPseudoPass(*PR);
   initializeRISCVExpandPseudoPass(*PR);
   initializeVentusPrintfRuntimeBindingPass(*PR);
+  initializeVentusPromoteAllocaPass(*PR);
 }
 
 static StringRef computeDataLayout(const Triple &TT, StringRef CPU) {
@@ -228,6 +229,9 @@ void RISCVPassConfig::addIRPasses() {
     addPass(createInferAddressSpacesPass());
   }
 
+  // Promote allocas to vector or local memory for Ventus GPU
+  addPass(createVentusPromoteAllocaPass());
+
   addPass(createAtomicExpandPass());
 
   if (getOptLevel() != CodeGenOpt::None)
@@ -308,7 +312,7 @@ void RISCVPassConfig::addMachineSSAOptimization() {
 
   if (TM->getTargetTriple().getArch() == Triple::riscv64)
     addPass(createRISCVSExtWRemovalPass());
-    
+
   // Disable Pre-RA Machine Sinking pass
   disablePass(&MachineSinkingID);
 }
@@ -329,7 +333,7 @@ void RISCVPassConfig::addPostRegAlloc() {
   // Do not work with OpPhi.
   disablePass(&BranchFolderPassID);
   disablePass(&MachineBlockPlacementID);
-  
+
   // Disable Post-RA Machine Sinking pass
   disablePass(&PostRAMachineSinkingID);
 

--- a/llvm/lib/Target/RISCV/VentusPromoteAlloca.cpp
+++ b/llvm/lib/Target/RISCV/VentusPromoteAlloca.cpp
@@ -1,0 +1,439 @@
+//===-- VentusPromoteAlloca.cpp - Promote Allocas -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass eliminates allocas by converting them into vectors.
+// Based on AMDGPU and AIGCGPU implementations.
+//
+//===----------------------------------------------------------------------===//
+
+#include "RISCV.h"
+#include "RISCVSubtarget.h"
+#include "llvm/Analysis/CaptureTracking.h"
+#include "llvm/Analysis/ValueTracking.h"
+#include "llvm/CodeGen/TargetPassConfig.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/Pass.h"
+#include "llvm/Target/TargetMachine.h"
+#include "llvm/Transforms/Utils/SSAUpdater.h"
+
+#define DEBUG_TYPE "ventus-promote-alloca"
+
+using namespace llvm;
+
+namespace {
+
+static cl::opt<bool> DisablePromoteAllocaToVector(
+    "disable-ventus-promote-alloca-to-vector",
+    cl::desc("Disable promote alloca to vector for Ventus"), cl::init(false));
+
+static cl::opt<unsigned> PromoteAllocaToVectorLimit(
+    "ventus-promote-alloca-to-vector-limit",
+    cl::desc("Maximum byte size to consider promote alloca to vector"),
+    cl::init(256));
+
+// TODO: promote larger vector to LDS
+
+
+class VentusPromoteAlloca : public FunctionPass {
+public:
+  static char ID;
+
+  VentusPromoteAlloca() : FunctionPass(ID) {}
+
+  bool runOnFunction(Function &F) override;
+
+  StringRef getPassName() const override { return "Ventus Promote Alloca"; }
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.setPreservesCFG();
+    FunctionPass::getAnalysisUsage(AU);
+  }
+};
+
+class VentusPromoteAllocaImpl {
+private:
+  const TargetMachine &TM;
+  Module *Mod = nullptr;
+  const DataLayout *DL = nullptr;
+  unsigned MaxVGPRs = 256;
+
+  bool tryPromoteAllocaToVector(AllocaInst &I);
+
+public:
+  VentusPromoteAllocaImpl(TargetMachine &TM) : TM(TM) {}
+  bool run(Function &F);
+};
+
+} // end anonymous namespace
+
+char VentusPromoteAlloca::ID = 0;
+
+INITIALIZE_PASS(VentusPromoteAlloca, DEBUG_TYPE,
+                "Ventus promote alloca to vector", false, false)
+
+char &llvm::VentusPromoteAllocaID = VentusPromoteAlloca::ID;
+
+bool VentusPromoteAlloca::runOnFunction(Function &F) {
+
+  if (auto *TPC = getAnalysisIfAvailable<TargetPassConfig>()) {
+    return VentusPromoteAllocaImpl(TPC->getTM<TargetMachine>()).run(F);
+  }
+  return false;
+}
+
+bool VentusPromoteAllocaImpl::run(Function &F) {
+  Mod = F.getParent();
+  DL = &Mod->getDataLayout();
+
+  bool Changed = false;
+  BasicBlock &EntryBB = *F.begin();
+
+  SmallVector<AllocaInst *, 16> Allocas;
+  for (Instruction &I : EntryBB) {
+    if (AllocaInst *AI = dyn_cast<AllocaInst>(&I)) {
+      if (!AI->isStaticAlloca() || AI->isArrayAllocation())
+        continue;
+      // Only handle allocas in private address space
+      if (AI->getAddressSpace() == RISCVAS::PRIVATE_ADDRESS)
+        Allocas.push_back(AI);
+    }
+  }
+
+  for (AllocaInst *AI : Allocas) {
+    if (tryPromoteAllocaToVector(*AI))
+      Changed = true;
+  }
+
+  return Changed;
+}
+
+static void collectAllocaUses(AllocaInst &Alloca,
+                              SmallVectorImpl<Use *> &Uses) {
+  SmallVector<Instruction *, 4> WorkList({&Alloca});
+  while (!WorkList.empty()) {
+    auto *Cur = WorkList.pop_back_val();
+    for (auto &U : Cur->uses()) {
+      Uses.push_back(&U);
+      if (isa<GetElementPtrInst>(U.getUser()))
+        WorkList.push_back(cast<Instruction>(U.getUser()));
+    }
+  }
+}
+
+static Value *calculateVectorIndex(
+    Value *Ptr, const std::map<GetElementPtrInst *, Value *> &GEPIdx) {
+  auto *GEP = dyn_cast<GetElementPtrInst>(Ptr->stripPointerCasts());
+  if (!GEP)
+    return ConstantInt::getNullValue(Type::getInt32Ty(Ptr->getContext()));
+
+  auto I = GEPIdx.find(GEP);
+  assert(I != GEPIdx.end() && "Must have entry for GEP!");
+  return I->second;
+}
+
+static Value *GEPToVectorIndex(GetElementPtrInst *GEP, AllocaInst *Alloca,
+                               Type *VecElemTy, const DataLayout &DL) {
+  unsigned BW = DL.getIndexTypeSizeInBits(GEP->getType());
+  MapVector<Value *, APInt> VarOffsets;
+  APInt ConstOffset(BW, 0);
+  if (GEP->getPointerOperand()->stripPointerCasts() != Alloca ||
+      !GEP->collectOffset(DL, BW, VarOffsets, ConstOffset))
+    return nullptr;
+
+  unsigned VecElemSize = DL.getTypeAllocSize(VecElemTy);
+  if (VarOffsets.size() > 1)
+    return nullptr;
+
+  if (VarOffsets.size() == 1) {
+    const auto &VarOffset = VarOffsets.front();
+    if (!ConstOffset.isZero() || VarOffset.second != VecElemSize)
+      return nullptr;
+    return VarOffset.first;
+  }
+
+  APInt Quot;
+  uint64_t Rem;
+  APInt::udivrem(ConstOffset, VecElemSize, Quot, Rem);
+  if (Rem != 0)
+    return nullptr;
+
+  return ConstantInt::get(GEP->getContext(), Quot);
+}
+
+static bool isSupportedAccessType(FixedVectorType *VecTy, Type *AccessTy,
+                                  const DataLayout &DL) {
+  if (isa<FixedVectorType>(AccessTy)) {
+    TypeSize AccTS = DL.getTypeStoreSize(AccessTy);
+    TypeSize VecTS = DL.getTypeStoreSize(VecTy->getElementType());
+    return AccTS.isKnownMultipleOf(VecTS);
+  }
+  return CastInst::isBitOrNoopPointerCastable(VecTy->getElementType(),
+                                              AccessTy, DL);
+}
+
+static Value *promoteAllocaUserToVector(
+    Instruction *Inst, const DataLayout &DL, FixedVectorType *VectorTy,
+    unsigned VecStoreSize, unsigned ElementSize,
+    std::map<GetElementPtrInst *, Value *> &GEPVectorIdx, Value *CurVal,
+    SmallVectorImpl<LoadInst *> &DeferredLoads) {
+
+  IRBuilder<> Builder(Inst);
+  Type *VecEltTy = VectorTy->getElementType();
+
+  const auto GetOrLoadCurrentVectorValue = [&]() -> Value * {
+    if (CurVal)
+      return CurVal;
+    LoadInst *Dummy =
+        Builder.CreateLoad(VectorTy, PoisonValue::get(Builder.getPtrTy()),
+                          "promotealloca.dummyload");
+    DeferredLoads.push_back(Dummy);
+    return Dummy;
+  };
+
+  switch (Inst->getOpcode()) {
+  case Instruction::Load: {
+    if (!CurVal) {
+      DeferredLoads.push_back(cast<LoadInst>(Inst));
+      return nullptr;
+    }
+    Value *Index = calculateVectorIndex(
+        cast<LoadInst>(Inst)->getPointerOperand(), GEPVectorIdx);
+    Type *AccessTy = Inst->getType();
+    TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
+
+    // Loading full vector
+    if (Constant *CI = dyn_cast<Constant>(Index)) {
+      if (CI->isZeroValue() && AccessSize == VecStoreSize) {
+        Value *NewVal = Builder.CreateBitOrPointerCast(CurVal, AccessTy);
+        Inst->replaceAllUsesWith(NewVal);
+        return nullptr;
+      }
+    }
+
+    // Loading single element
+    Value *ExtractElement = Builder.CreateExtractElement(CurVal, Index);
+    if (AccessTy != VecEltTy)
+      ExtractElement = Builder.CreateBitOrPointerCast(ExtractElement, AccessTy);
+    Inst->replaceAllUsesWith(ExtractElement);
+    return nullptr;
+  }
+  case Instruction::Store: {
+    StoreInst *SI = cast<StoreInst>(Inst);
+    Value *Index = calculateVectorIndex(SI->getPointerOperand(), GEPVectorIdx);
+    Value *Val = SI->getValueOperand();
+    Type *AccessTy = Val->getType();
+    TypeSize AccessSize = DL.getTypeStoreSize(AccessTy);
+
+    // Storing full vector
+    if (Constant *CI = dyn_cast<Constant>(Index)) {
+      if (CI->isZeroValue() && AccessSize == VecStoreSize) {
+        return Builder.CreateBitOrPointerCast(Val, VectorTy);
+      }
+    }
+
+    // Storing single element
+    if (Val->getType() != VecEltTy)
+      Val = Builder.CreateBitOrPointerCast(Val, VecEltTy);
+    return Builder.CreateInsertElement(GetOrLoadCurrentVectorValue(), Val,
+                                      Index);
+  }
+  default:
+    llvm_unreachable("Unsupported instruction in promoteAllocaUserToVector");
+  }
+}
+
+template <typename InstContainer>
+static void forEachWorkListItem(const InstContainer &WorkList,
+                                std::function<void(Instruction *)> Fn) {
+  DenseMap<BasicBlock *, SmallDenseSet<Instruction *>> UsesByBlock;
+  for (Instruction *User : WorkList)
+    UsesByBlock[User->getParent()].insert(User);
+
+  for (Instruction *User : WorkList) {
+    BasicBlock *BB = User->getParent();
+    auto &BlockUses = UsesByBlock[BB];
+    if (BlockUses.empty())
+      continue;
+
+    if (BlockUses.size() == 1) {
+      Fn(User);
+      continue;
+    }
+
+    for (Instruction &Inst : *BB) {
+      if (!BlockUses.contains(&Inst))
+        continue;
+      Fn(&Inst);
+    }
+    BlockUses.clear();
+  }
+}
+
+bool VentusPromoteAllocaImpl::tryPromoteAllocaToVector(AllocaInst &Alloca) {
+  LLVM_DEBUG(dbgs() << "Trying to promote to vector: " << Alloca << '\n');
+
+  if (DisablePromoteAllocaToVector) {
+    LLVM_DEBUG(dbgs() << "  Promotion disabled\n");
+    return false;
+  }
+
+  Type *AllocaTy = Alloca.getAllocatedType();
+  auto *VectorTy = dyn_cast<FixedVectorType>(AllocaTy);
+
+  // Convert array to vector
+  if (auto *ArrayTy = dyn_cast<ArrayType>(AllocaTy)) {
+    if (VectorType::isValidElementType(ArrayTy->getElementType()) &&
+        ArrayTy->getNumElements() > 0)
+      VectorTy = FixedVectorType::get(ArrayTy->getElementType(),
+                                     ArrayTy->getNumElements());
+  }
+
+  if (!VectorTy) {
+    LLVM_DEBUG(dbgs() << "  Cannot convert type to vector\n");
+    return false;
+  }
+
+  // Check size limit
+  unsigned AllocaSize = DL->getTypeSizeInBits(AllocaTy);
+  if (AllocaSize > PromoteAllocaToVectorLimit * 8) {
+    LLVM_DEBUG(dbgs() << "  Alloca too big: " << AllocaSize << " bits\n");
+    return false;
+  }
+
+  if (VectorTy->getNumElements() > 16 || VectorTy->getNumElements() < 1) {
+    LLVM_DEBUG(dbgs() << "  Invalid vector size\n");
+    return false;
+  }
+
+  // Collect and validate uses
+  std::map<GetElementPtrInst *, Value *> GEPVectorIdx;
+  SmallVector<Instruction *> WorkList;
+  SmallVector<Instruction *> UsersToRemove;
+  SmallVector<Use *, 8> Uses;
+  collectAllocaUses(Alloca, Uses);
+
+  Type *VecEltTy = VectorTy->getElementType();
+  unsigned ElementSize = DL->getTypeSizeInBits(VecEltTy) / 8;
+
+  const auto RejectUser = [&](Instruction *Inst, const char *Msg) {
+    LLVM_DEBUG(dbgs() << "  Cannot promote: " << Msg << "\n"
+                      << "    " << *Inst << "\n");
+    return false;
+  };
+
+  for (auto *U : Uses) {
+    Instruction *Inst = cast<Instruction>(U->getUser());
+
+    if (Value *Ptr = getLoadStorePointerOperand(Inst)) {
+      if (isa<StoreInst>(Inst) &&
+          U->getOperandNo() != StoreInst::getPointerOperandIndex())
+        return RejectUser(Inst, "storing pointer");
+
+      Type *AccessTy = getLoadStoreType(Inst);
+      bool IsSimple = isa<LoadInst>(Inst) ? cast<LoadInst>(Inst)->isSimple()
+                                          : cast<StoreInst>(Inst)->isSimple();
+      if (!IsSimple)
+        return RejectUser(Inst, "not simple load/store");
+
+      Ptr = Ptr->stripPointerCasts();
+      if (Ptr == &Alloca &&
+          DL->getTypeStoreSize(Alloca.getAllocatedType()) ==
+              DL->getTypeStoreSize(AccessTy)) {
+        WorkList.push_back(Inst);
+        continue;
+      }
+
+      if (!isSupportedAccessType(VectorTy, AccessTy, *DL))
+        return RejectUser(Inst, "unsupported access type");
+
+      WorkList.push_back(Inst);
+      continue;
+    }
+
+    if (auto *GEP = dyn_cast<GetElementPtrInst>(Inst)) {
+      Value *Index = GEPToVectorIndex(GEP, &Alloca, VecEltTy, *DL);
+      if (!Index)
+        return RejectUser(Inst, "cannot compute GEP index");
+      GEPVectorIdx[GEP] = Index;
+      UsersToRemove.push_back(Inst);
+      continue;
+    }
+
+    if (isAssumeLikeIntrinsic(Inst)) {
+      UsersToRemove.push_back(Inst);
+      continue;
+    }
+
+    if (isa<ICmpInst>(Inst) && all_of(Inst->users(), [](User *U) {
+          return isAssumeLikeIntrinsic(cast<Instruction>(U));
+        })) {
+      UsersToRemove.push_back(Inst);
+      continue;
+    }
+
+    return RejectUser(Inst, "unhandled user");
+  }
+
+  LLVM_DEBUG(dbgs() << "  Converting to vector: " << *VectorTy << '\n');
+
+  const unsigned VecStoreSize = DL->getTypeStoreSize(VectorTy);
+
+  // Use SSAUpdater for cross-block promotion
+  SSAUpdater Updater;
+  Updater.Initialize(VectorTy, "promotealloca");
+  Updater.AddAvailableValue(Alloca.getParent(), UndefValue::get(VectorTy));
+
+  SmallVector<LoadInst *, 4> DeferredLoads;
+
+  // First pass: process instructions with known values
+  forEachWorkListItem(WorkList, [&](Instruction *I) {
+    BasicBlock *BB = I->getParent();
+    Value *Result = promoteAllocaUserToVector(
+        I, *DL, VectorTy, VecStoreSize, ElementSize, GEPVectorIdx,
+        Updater.FindValueForBlock(BB), DeferredLoads);
+    if (Result)
+      Updater.AddAvailableValue(BB, Result);
+  });
+
+  // Second pass: process deferred loads
+  forEachWorkListItem(DeferredLoads, [&](Instruction *I) {
+    SmallVector<LoadInst *, 0> NewDLs;
+    BasicBlock *BB = I->getParent();
+    Value *Result = promoteAllocaUserToVector(
+        I, *DL, VectorTy, VecStoreSize, ElementSize, GEPVectorIdx,
+        Updater.GetValueInMiddleOfBlock(BB), NewDLs);
+    if (Result)
+      Updater.AddAvailableValue(BB, Result);
+    assert(NewDLs.empty() && "No more deferred loads!");
+  });
+
+  // Delete instructions
+  DenseSet<Instruction *> InstsToDelete(WorkList.begin(), WorkList.end());
+  InstsToDelete.insert(DeferredLoads.begin(), DeferredLoads.end());
+  for (Instruction *I : InstsToDelete) {
+    assert(I->use_empty());
+    I->eraseFromParent();
+  }
+
+  for (Instruction *I : reverse(UsersToRemove)) {
+    I->dropDroppableUses();
+    assert(I->use_empty());
+    I->eraseFromParent();
+  }
+
+  assert(Alloca.use_empty());
+  Alloca.eraseFromParent();
+
+  return true;
+}
+
+
+FunctionPass *llvm::createVentusPromoteAllocaPass() {
+  return new VentusPromoteAlloca();
+}

--- a/llvm/test/CodeGen/RISCV/VentusGPGPU/ventus-promote-alloca.ll
+++ b/llvm/test/CodeGen/RISCV/VentusGPGPU/ventus-promote-alloca.ll
@@ -1,0 +1,123 @@
+; RUN: llc -march=riscv32 -mcpu=ventus-gpgpu -mattr=+f,+d -stop-after=ventus-promote-alloca < %s | FileCheck %s
+
+;===----------------------------------------------------------------------===//
+; Test case for VentusPromoteAlloca pass
+;
+; VentusPromoteAlloca eliminates stack allocations (alloca) in private address
+; space (addrspace 5), converting them to SSA values (registers/vectors). This
+; is a mem2reg optimization specifically for GPU private memory.
+;
+; Pass workflow:
+; 1. Identify allocas in private address space (addrspace 5)
+; 2. Verify all uses are simple load/store or convertible GEP
+; 3. Convert loads to extractelement, stores to insertelement
+; 4. Use SSAUpdater to track values across basic blocks
+; 5. Eliminate alloca and all memory operations
+;
+; Optimization benefits:
+; - Replace slow memory operations with fast register operations
+; - Reduce private memory (stack) usage
+; - Create more opportunities for subsequent optimizations
+;===----------------------------------------------------------------------===//
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32-S128"
+target triple = "riscv32-unknown-unknown"
+
+; Test 1: Basic vector alloca promotion
+; Verify that simple vector alloca and its load/store are eliminated and converted to direct SSA value usage
+define ventus_kernel void @test_basic_vector(ptr addrspace(1) noundef align 16 %out) {
+; CHECK-LABEL: define ventus_kernel void @test_basic_vector
+; CHECK-NOT: alloca
+; CHECK: store <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>, ptr addrspace(1) %out
+entry:
+  %vec1 = alloca <4 x float>, align 16, addrspace(5)
+  %vec2 = alloca <4 x float>, align 16, addrspace(5)
+  store <4 x float> <float 1.0, float 2.0, float 3.0, float 4.0>, ptr addrspace(5) %vec2, align 16
+  %tmp = load <4 x float>, ptr addrspace(5) %vec2, align 16
+  store <4 x float> %tmp, ptr addrspace(5) %vec1, align 16
+  %result = load <4 x float>, ptr addrspace(5) %vec1, align 16
+  store <4 x float> %result, ptr addrspace(1) %out, align 16
+  ret void
+}
+
+; Test 2: Array to vector conversion
+; Verify that arrays can be converted to vectors and promoted
+define ventus_kernel void @test_array_to_vector(ptr addrspace(1) noundef %out) {
+; CHECK-LABEL: define ventus_kernel void @test_array_to_vector
+; CHECK-NOT: alloca
+; CHECK-NOT: getelementptr
+; CHECK: %sum = add i32 10, 20
+; CHECK: store i32 %sum, ptr addrspace(1) %out
+entry:
+  %arr = alloca [4 x i32], align 16, addrspace(5)
+  %ptr0 = getelementptr inbounds [4 x i32], ptr addrspace(5) %arr, i32 0, i32 0
+  store i32 10, ptr addrspace(5) %ptr0, align 4
+  %ptr1 = getelementptr inbounds [4 x i32], ptr addrspace(5) %arr, i32 0, i32 1
+  store i32 20, ptr addrspace(5) %ptr1, align 4
+  %val0 = load i32, ptr addrspace(5) %ptr0, align 4
+  %val1 = load i32, ptr addrspace(5) %ptr1, align 4
+  %sum = add i32 %val0, %val1
+  store i32 %sum, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+; Test 3: Cross-block promotion using SSAUpdater
+; Verify that the pass correctly handles allocas used across multiple basic blocks
+define ventus_kernel void @test_cross_block(i32 %cond, ptr addrspace(1) noundef %out) {
+; CHECK-LABEL: define ventus_kernel void @test_cross_block
+; CHECK-NOT: alloca
+; CHECK: %vec.0 = phi <2 x i32> [ <i32 1, i32 2>, %if.then ], [ <i32 3, i32 4>, %if.else ]
+; CHECK: store <2 x i32> %vec.0, ptr addrspace(1) %out
+entry:
+  %vec = alloca <2 x i32>, align 8, addrspace(5)
+  %tobool = icmp ne i32 %cond, 0
+  br i1 %tobool, label %if.then, label %if.else
+
+if.then:
+  store <2 x i32> <i32 1, i32 2>, ptr addrspace(5) %vec, align 8
+  br label %if.end
+
+if.else:
+  store <2 x i32> <i32 3, i32 4>, ptr addrspace(5) %vec, align 8
+  br label %if.end
+
+if.end:
+  %result = load <2 x i32>, ptr addrspace(5) %vec, align 8
+  store <2 x i32> %result, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+; Test 4: Element access using extractelement
+; Verify that GEP-based element access is converted to extractelement operations
+define ventus_kernel void @test_element_access(ptr addrspace(1) noundef %out) {
+; CHECK-LABEL: define ventus_kernel void @test_element_access
+; CHECK-NOT: alloca
+; CHECK-NOT: getelementptr
+; CHECK: extractelement <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>, i32 2
+; CHECK: store float {{.*}}, ptr addrspace(1) %out
+entry:
+  %vec = alloca <4 x float>, align 16, addrspace(5)
+  store <4 x float> <float 1.0, float 2.0, float 3.0, float 4.0>, ptr addrspace(5) %vec, align 16
+  %ptr2 = getelementptr inbounds <4 x float>, ptr addrspace(5) %vec, i32 0, i32 2
+  %elem2 = load float, ptr addrspace(5) %ptr2, align 4
+  store float %elem2, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+; Test 5: Partial vector update using insertelement
+; Verify that partial updates of vector elements work correctly
+define ventus_kernel void @test_partial_update(float %newval, ptr addrspace(1) noundef %out) {
+; CHECK-LABEL: define ventus_kernel void @test_partial_update
+; CHECK-NOT: alloca
+; CHECK: insertelement <4 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 4.000000e+00>, float %newval, i32 1
+; CHECK: store <4 x float> {{.*}}, ptr addrspace(1) %out
+entry:
+  %vec = alloca <4 x float>, align 16, addrspace(5)
+  store <4 x float> <float 1.0, float 2.0, float 3.0, float 4.0>, ptr addrspace(5) %vec, align 16
+  %ptr1 = getelementptr inbounds <4 x float>, ptr addrspace(5) %vec, i32 0, i32 1
+  store float %newval, ptr addrspace(5) %ptr1, align 4
+  %result = load <4 x float>, ptr addrspace(5) %vec, align 16
+  store <4 x float> %result, ptr addrspace(1) %out, align 16
+  ret void
+}
+


### PR DESCRIPTION
支持vector类型<=16长度的变量，使用寄存器存，不用VLW/VSW来存取